### PR TITLE
整理命令格式，去尾部空格，部分补充

### DIFF
--- a/index/命令1-命令操作.md
+++ b/index/命令1-命令操作.md
@@ -10,13 +10,13 @@
     - [【教程】[1.15] execute 命令入门教程 ](/datapack-index/save/989501.html){target="_blank"}
     - [【CBL|SYL】【1.13】新版本execute嵌套的改变](/datapack-index/save/770198.html){target="_blank"}
     - [【Minecraft】“新”execute你会用吗？应当如何正确食用新语法？](https://www.bilibili.com/video/BV1B14y187Zy)
-    - (不推荐) [[1.13+]新版execute命令详解](/datapack-index/save/901364.html){target="_blank"} 
-    - (不推荐)[玩转1.13的新/execute](/datapack-index/save/770738.html){target="_blank"} 
+    - (不推荐) [[1.13+]新版execute命令详解](/datapack-index/save/901364.html){target="_blank"}
+    - (不推荐)[玩转1.13的新/execute](/datapack-index/save/770738.html){target="_blank"}
   - 修饰子命令：
     - 执行者 `as | on | summon`
       - 直接指定`as`
       - 设为相关实体`on`
-      - 生成新实体并指定为执行者`summon` 
+      - 生成新实体并指定为执行者`summon`
 
     - 朝向 `rotated | rotated as | facing | facing entity`
 
@@ -37,7 +37,7 @@
   - 执行子命令`run`
 
 ## 命令逻辑
-  
+
   - 命令方块 (淘汰)
       [1.12 连锁命令方块(CCB)新机制研究](/datapack-index/save/687963.html){target="_blank"}
   - 数据包结构逻辑

--- a/index/命令2-数据操作.md
+++ b/index/命令2-数据操作.md
@@ -1,11 +1,10 @@
 # 数据操作
 
-### [NBT](https://zh.minecraft.wiki/w/NBT%E6%A0%BC%E5%BC%8F)(数据储存/修改) 
-#### 古典教程 
+### [NBT](https://zh.minecraft.wiki/w/NBT%E6%A0%BC%E5%BC%8F)(数据储存/修改)
+#### 古典教程
   - [【CBL|SYL】NBT标签实战教程—索引贴(基本完工) ](/datapack-index/save/78479.html){target="_blank"}
   - [~~2.2 NBT及结构 · 命令进阶 (oschina.io)~~](https://mc-command.oschina.io/command-tutorial/output/common-format/nbt/nbt.html){target="_blank"}（疑似无法访问）
-#### （不太）现代教程 
-  - [~~( X ) 我就不信不能用大白话讲清楚NBT~~](/datapack-index/save/1190947.html){target="_blank"} 
+#### （不太）现代教程
   - [教程/NBT命令标签](https://zh.minecraft.wiki/w/教程/NBT命令标签)
   - [(十一)NBT通俗演义（雾）](https://www.bilibili.com/opus/947507675726348296)
 #### ~~物品NBT~~ [物品组件](https://zh.minecraft.wiki/w/%E7%89%A9%E5%93%81%E5%A0%86%E5%8F%A0%E7%BB%84%E4%BB%B6)

--- a/index/命令4-方块和物品操作.md
+++ b/index/命令4-方块和物品操作.md
@@ -2,22 +2,24 @@
 
 ## 方块操作
 
-### [结构方块](https://zh.minecraft.wiki/w/%E7%BB%93%E6%9E%84%E6%96%B9%E5%9D%97) 
+### [结构方块](https://zh.minecraft.wiki/w/?curid=17934)
   - [【1.10新特性】结构方块从入门到放弃](/datapack-index/save/585095.html){target="_blank"}
   - [[1.14+] 组合结构的随机生成及修饰](/datapack-index/save/899638.html){target="_blank"}
   - [如何使用结构方块](/datapack-index/save/652937.html){target="_blank"}
   - [【新手向】建筑党也能愉快享用结构方块-图文并茂教会你使用结构方块](/datapack-index/save/801350.html){target="_blank"}
-### 加载结构 
+### 加载结构
+  - 使用命令 [/place](https://zh.minecraft.wiki/w/?curid=95979)
+  - 使用结构方块
   ```mcfunction
   execute at @p run setblock ~ ~ ~ structure_block{name:"woodland_mansion/1x1_a3",mode:"LOAD",powered:0}
-  execute at @p run setblock ~ ~-1 ~ redstone_block 
+  execute at @p run setblock ~ ~-1 ~ redstone_block
   ```
 
-### 放置方块 [/setblock](https://zh.minecraft.wiki/w/%E5%91%BD%E4%BB%A4/setblock) 
+### 放置方块 [/setblock](https://zh.minecraft.wiki/w/?curid=39810)
   - [(十)简单又新手（雾）的方块指令/setblock](https://www.bilibili.com/opus/942368755971784728)
-### 复制区域 [/clone](https://zh.minecraft.wiki/w/%E5%91%BD%E4%BB%A4/clone) 
+### 复制区域 [/clone](https://zh.minecraft.wiki/w/?curid=39642)
   - [(十五)复制一片区域：复制命令/clone](https://www.bilibili.com/read/cv38861264/)
-### 填充区域 [/fill](https://zh.minecraft.wiki/w/%E5%91%BD%E4%BB%A4/fill) 
+### 填充区域 [/fill](https://zh.minecraft.wiki/w/%E5%91%BD%E4%BB%A4/fill)
   - [(十四) 最接近神的一次：填充命令/fill](https://www.bilibili.com/read/cv37972439/)
 ### 修改生物群系 [/fillbiome](https://zh.minecraft.wiki/w/命令/fillbiome)
 
@@ -30,7 +32,7 @@
 ### 给予物品 [/give](https://zh.minecraft.wiki/w/%E5%91%BD%E4%BB%A4/give)
 
 ### 置入战利品表 [/loot](https://zh.minecraft.wiki/w/%E5%91%BD%E4%BB%A4/loot)
-  - [rua影盒](https://zhangshenxing.github.io/VanillaModTutorial/#%E4%BF%AE%E6%94%B9%E7%8E%A9%E5%AE%B6%E8%83%8C%E5%8C%85) 
+  - [rua影盒](https://zhangshenxing.github.io/VanillaModTutorial/#%E4%BF%AE%E6%94%B9%E7%8E%A9%E5%AE%B6%E8%83%8C%E5%8C%85)
   - [[1.14]如何使用loot replace](/datapack-index/save/874755.html){target="_blank"}
   - 内联战利品表/谓词/物品修饰器
 
@@ -38,4 +40,4 @@
 
 ### 修改物品栈
   - 1.17+ [/item](https://zh.minecraft.wiki/w/%E5%91%BD%E4%BB%A4/item)
-  - 1.16- [/replaceitem](https://zh.minecraft.wiki/w/%E5%91%BD%E4%BB%A4/replaceitem) 
+  - 1.16- [/replaceitem](https://zh.minecraft.wiki/w/%E5%91%BD%E4%BB%A4/replaceitem)

--- a/index/命令5-实体操作.md
+++ b/index/命令5-实体操作.md
@@ -19,20 +19,21 @@
 
   - 播放 [/playsound](https://zh.minecraft.wiki/w/%E5%91%BD%E4%BB%A4/playsound)
 
-    - playsound <*声音 entity.pig.ambient*> <*来源*> <*玩家名|目标选择器*> [<*方位x y z*>] [<*音量*>] [<*音调0.0~2.0*>] [<*最小音量0.0~1.0*>]
+    - playsound <声音命名空间ID> <来源> <目标> [<方位x y z>] [<音量>] [<音调0.0~2.0>] [<最小音量0.0~1.0>]
       来源：master,music,record,weather,block,hostile,neutral,player,ambient,voice
 
   - 停止 [/stopsound](https://zh.minecraft.wiki/w/%E5%91%BD%E4%BB%A4/stopsound)
 
-    - stopsound <*玩家名|目标选择器*> [*来源*] [*声音*]
+    - stopsound <目标> [<来源>] [<声音命名空间ID>]
           来源：可以为 “ * ”
 
 ### 骑乘 [/ride](https://zh.minecraft.wiki/w/命令/ride)
 ### 传送
   - 随机传送 [/spreadplayers](https://zh.minecraft.wiki/w/%E5%91%BD%E4%BB%A4/spreadplayers)
-    - `spreadplayers <*x*> <*z*> <*分散间距*> <*最大范围*> [*under* *最大高度*] <*考虑队伍*> <*传送目标…*>`
+    - `spreadplayers <x> <z> <分散间距> <最大范围> [under <最大高度>] <考虑队伍> <传送目标…>`
 
   - 传送 [/teleport](https://zh.minecraft.wiki/w/%E5%91%BD%E4%BB%A4/teleport) [/tp](https://zh.minecraft.wiki/w/%E5%91%BD%E4%BB%A4/tp)
+    - [(二) 命令tp与相对，局部坐标与朝向锚](https://www.bilibili.com/read/cv34840247)
     - [~~teleport 相对坐标 本地坐标 省略选择器~~](/datapack-index/save/1114273.html){target="_blank"}
 ### 旋转 [/rotate](https://zh.minecraft.wiki/w/命令/rotate)
 
@@ -51,6 +52,6 @@
   - [(六) /tag指令，与进阶选择器参数](https://www.bilibili.com/opus/937149730721366018)
 
 ### 其他
-    
-  - 经验 [/experience](https://zh.minecraft.wiki/w/%E5%91%BD%E4%BB%A4/experience) [/xp](https://zh.minecraft.wiki/w/%E5%91%BD%E4%BB%A4/xp) 
+
+  - 经验 [/experience](https://zh.minecraft.wiki/w/%E5%91%BD%E4%BB%A4/experience) [/xp](https://zh.minecraft.wiki/w/%E5%91%BD%E4%BB%A4/xp)
   - 旁观实体 [/spectate](https://zh.minecraft.wiki/w/%E5%91%BD%E4%BB%A4/spectate)

--- a/index/命令6-世界指令.md
+++ b/index/命令6-世界指令.md
@@ -3,20 +3,21 @@
 ## 世界操作
 
   - [游戏模式](https://zh.minecraft.wiki/w/%E6%B8%B8%E6%88%8F%E6%A8%A1%E5%BC%8F)
-    
+
     - 世界模式 [/defaultgamemode](https://zh.minecraft.wiki/w/%E5%91%BD%E4%BB%A4/defaultgamemode)
     - 玩家模式 [/gamemode](https://zh.minecraft.wiki/w/%E5%91%BD%E4%BB%A4/gamemode)
 
   - 游戏难度 [/difficulty](https://zh.minecraft.wiki/w/%E5%91%BD%E4%BB%A4/difficulty)
 
-  - 游戏规则 [/gamerule](https://zh.minecraft.wiki/w/%E5%91%BD%E4%BB%A4/gamerule) 
+  - 游戏规则 [/gamerule](https://zh.minecraft.wiki/w/%E5%91%BD%E4%BB%A4/gamerule)
+    - [(九) /gamerule与游戏规则全解](https://www.bilibili.com/opus/938827778778726471)
 
-  - 结构位置 [/locate <structure|biome>](https://zh.minecraft.wiki/w/%E5%91%BD%E4%BB%A4/locate) 
+  - 结构位置 [/locate <structure|biome|poi>](https://zh.minecraft.wiki/w/%E5%91%BD%E4%BB%A4/locate)
 
   - 世界种子 [/seed](https://zh.minecraft.wiki/w/%E5%91%BD%E4%BB%A4/seed)
 
-  - [出生点](https://www.mcbbs.net/forum.php?mod=viewthread&tid=1182418&page=1#pid21460488) 
-    
+  - [出生点](https://www.mcbbs.net/forum.php?mod=viewthread&tid=1182418&page=1#pid21460488)
+
     - 世界出生点 [/setworldspawn](https://zh.minecraft.wiki/w/%E5%91%BD%E4%BB%A4/setworldspawn)
     - 玩家出生点 [/spawnpoint](https://zh.minecraft.wiki/w/%E5%91%BD%E4%BB%A4/spawnpoint)
 
@@ -28,11 +29,11 @@
 
   - 强制区块运行 [/forceload](https://zh.minecraft.wiki/w/%E5%91%BD%E4%BB%A4/forceload)
 
-  - [(八) 区块与强制加载命令/forceload](https://www.bilibili.com/opus/937515275404705808)
+    - [(八) 区块与强制加载命令/forceload](https://www.bilibili.com/opus/937515275404705808)
   - 游戏刻速率 [/tick](https://zh.minecraft.wiki/w/命令/tick)
 
 ## 外部命令
-    
+
   | 命令                                                                 | 描述                                   |
   | -------------------------------------------------------------------- | -------------------------------------- |
   | [/datapack](https://zh.minecraft.wiki/w/%E5%91%BD%E4%BB%A4/datapack) | 控制加载的数据包。                     |
@@ -40,23 +41,23 @@
   | [/reload](https://zh.minecraft.wiki/w/%E5%91%BD%E4%BB%A4/reload)     | 从硬盘中重新加载战利品表、进度和函数。 |
 
 ## 服务器操作
-    
+
   | 命令                                                                             | 描述                           | 语法                                                                                               |
   | -------------------------------------------------------------------------------- | ------------------------------ | -------------------------------------------------------------------------------------------------- |
-  | [/ban](https://zh.minecraft.wiki/w/%E5%91%BD%E4%BB%A4/ban)                       | 将玩家加入封禁列表。           | ban <*玩家名\|UUID*> [<*理由…*>]                                                                   |
-  | [/ban-ip](https://zh.minecraft.wiki/w/%E5%91%BD%E4%BB%A4/ban-ip)                 | 将IP地址加入封禁列表。         | ban-ip <*玩家名\|IP地址*> [<*理由…*>]                                                              |
+  | [/ban](https://zh.minecraft.wiki/w/%E5%91%BD%E4%BB%A4/ban)                       | 将玩家加入封禁列表。           | ban <玩家名\|UUID> [<理由…>]                                                                   |
+  | [/ban-ip](https://zh.minecraft.wiki/w/%E5%91%BD%E4%BB%A4/ban-ip)                 | 将IP地址加入封禁列表。         | ban-ip <玩家名\|IP地址> [<理由…>]                                                              |
   | [/banlist](https://zh.minecraft.wiki/w/%E5%91%BD%E4%BB%A4/banlist)               | 显示封禁列表。                 | banlist ips <br />banlist players                                                                  |
-  | [/deop](https://zh.minecraft.wiki/w/%E5%91%BD%E4%BB%A4/deop)                     | 撤销玩家的管理员权限。         | deop <*玩家*>                                                                                      |
-  | [/kick](https://zh.minecraft.wiki/w/%E5%91%BD%E4%BB%A4/kick)                     | 将玩家踢出服务器。             | kick <*玩家名\|目标选择器*> [*原因*]                                                               |
-  | [/list](https://zh.minecraft.wiki/w/%E5%91%BD%E4%BB%A4/list)                     | 列出服务器中的玩家。           | list [*uuids*]                                                                                     |
-  | [/op](https://zh.minecraft.wiki/w/%E5%91%BD%E4%BB%A4/op)                         | 授予玩家管理员权限。           | op <*玩家名\|目标选择器）*>                                                                        |
-  | [/pardon](https://zh.minecraft.wiki/w/%E5%91%BD%E4%BB%A4/pardon)                 | 从封禁列表中移除玩家封禁项目。 | pardon <*玩家名*>                                                                                  |
-  | [/pardon-ip](https://zh.minecraft.wiki/w/%E5%91%BD%E4%BB%A4/pardon-ip)           | 从封禁列表中移除IP封禁项目。   | pardon-ip <*IP地址*>                                                                               |
-  | [/publish](https://zh.minecraft.wiki/w/%E5%91%BD%E4%BB%A4/publish)               | 向局域网开放单人游戏世界。     | publish [*端口0~65536*]                                                                            |
+  | [/deop](https://zh.minecraft.wiki/w/%E5%91%BD%E4%BB%A4/deop)                     | 撤销玩家的管理员权限。         | deop <玩家>                                                                                      |
+  | [/kick](https://zh.minecraft.wiki/w/%E5%91%BD%E4%BB%A4/kick)                     | 将玩家踢出服务器。             | kick <玩家名\|目标选择器> [<原因>]                                                               |
+  | [/list](https://zh.minecraft.wiki/w/%E5%91%BD%E4%BB%A4/list)                     | 列出服务器中的玩家。           | list [uuids]                                                                                     |
+  | [/op](https://zh.minecraft.wiki/w/%E5%91%BD%E4%BB%A4/op)                         | 授予玩家管理员权限。           | op <玩家名\|目标选择器>                                                                        |
+  | [/pardon](https://zh.minecraft.wiki/w/%E5%91%BD%E4%BB%A4/pardon)                 | 从封禁列表中移除玩家封禁项目。 | pardon <玩家名>                                                                                  |
+  | [/pardon-ip](https://zh.minecraft.wiki/w/%E5%91%BD%E4%BB%A4/pardon-ip)           | 从封禁列表中移除IP封禁项目。   | pardon-ip <IP地址>                                                                               |
+  | [/publish](https://zh.minecraft.wiki/w/%E5%91%BD%E4%BB%A4/publish)               | 向局域网开放单人游戏世界。     | publish [<端口(0~65536)>]                                                                            |
   | [/save-all](https://zh.minecraft.wiki/w/%E5%91%BD%E4%BB%A4/save-all)             | 保存服务器世界状态到硬盘。     | save-all [flush]<br />flush:服务器会立即保存所有的区块数据                                         |
   | [/save-off](https://zh.minecraft.wiki/w/%E5%91%BD%E4%BB%A4/save-off)             | 关闭服务器自动保存。           | save-off                                                                                           |
   | [/save-on](https://zh.minecraft.wiki/w/%E5%91%BD%E4%BB%A4/save-on)               | 开启服务器自动保存。           | save-on                                                                                            |
-  | [/setidletimeout](https://zh.minecraft.wiki/w/%E5%91%BD%E4%BB%A4/setidletimeout) | 设置无操作玩家被踢出的延时。   | setidletimeout <*空闲分钟数0~2147483647*>                                                          |
+  | [/setidletimeout](https://zh.minecraft.wiki/w/%E5%91%BD%E4%BB%A4/setidletimeout) | 设置无操作玩家被踢出的延时。   | setidletimeout <空闲分钟数0~2147483647>                                                          |
   | [/stop](https://zh.minecraft.wiki/w/%E5%91%BD%E4%BB%A4/stop)                     | 关闭服务器。                   | stop                                                                                               |
-  | [/transfer](https://zh.minecraft.wiki/w/%E5%91%BD%E4%BB%A4/transfer)             | 将玩家转移到另一个服务器上。   | transfer <*hostname*> [<*port*>] [<*players*>]                                                       |
-  | [/whitelist](https://zh.minecraft.wiki/w/%E5%91%BD%E4%BB%A4/whitelist)           | 管理服务器白名单。             | whitelist add <*玩家*><br />whitelist remove <*玩家*><br />whitelist <list\|off\|on\|reload><br /> |
+  | [/transfer](https://zh.minecraft.wiki/w/%E5%91%BD%E4%BB%A4/transfer)             | 将玩家转移到另一个服务器上。   | transfer <hostname> [<port>] [<players>]                                                       |
+  | [/whitelist](https://zh.minecraft.wiki/w/%E5%91%BD%E4%BB%A4/whitelist)           | 管理服务器白名单。             | whitelist add <玩家><br />whitelist remove <玩家><br />whitelist <list\|off\|on\|reload><br /> |

--- a/index/数据结构.md
+++ b/index/数据结构.md
@@ -37,7 +37,7 @@
   - [标签 - Minecraft Wiki](https://zh.minecraft.wiki/w/标签)
   - [【UIN】数据包——标签分类](/datapack-index/save/775667.html){target="_blank"}
   - [Minecraft 原版模组入门教程-标签](https://zhangshenxing.github.io/VanillaModTutorial/#标签)
-  - [哪些命令中的哪些部分可以使用标签 ](/datapack-index/save/963143.html){target="_blank"} 
+  - [哪些命令中的哪些部分可以使用标签 ](/datapack-index/save/963143.html){target="_blank"}
   - [数据包标签的使用问题](/datapack-index/save/989540.html){target="_blank"}
 
 ### 配方

--- a/index/绪论.md
+++ b/index/绪论.md
@@ -2,19 +2,19 @@
 
 
 ## 绪论
-[数据包 - Minecraft Wiki ](https://zh.minecraft.wiki/w/%E6%95%B0%E6%8D%AE%E5%8C%85)([Bwiki镜像](https://wiki.biligame.com/mc/数据包))  
-[资源包 - Minecraft Wiki ](https://zh.minecraft.wiki/w/%E8%B5%84%E6%BA%90%E5%8C%85)([Bwiki镜像](https://wiki.biligame.com/mc/资源包))  
+[数据包 - Minecraft Wiki ](https://zh.minecraft.wiki/w/%E6%95%B0%E6%8D%AE%E5%8C%85)([Bwiki镜像](https://wiki.biligame.com/mc/数据包))
+[资源包 - Minecraft Wiki ](https://zh.minecraft.wiki/w/%E8%B5%84%E6%BA%90%E5%8C%85)([Bwiki镜像](https://wiki.biligame.com/mc/资源包))
 [命令 - Minecraft Wiki ](https://zh.minecraft.wiki/w/%E5%91%BD%E4%BB%A4)([Bwiki镜像](https://wiki.biligame.com/mc/命令))
 
-[Minecraft 原版模组入门教程 ](https://zhangshenxing.github.io/VanillaModTutorial/) ~~(坛内)~~  
+[Minecraft 原版模组入门教程 ](https://zhangshenxing.github.io/VanillaModTutorial/) ~~(坛内)~~
 [~~数据包/资源包常见问题索引以及一点资源(JE~~](/datapack-index/save/1233623.html){target="_blank"}
 
-原版模组是数据包和资源包配合的系统工程，其中数据包部分的重中之重是命令组成的函数。因此，请读者清楚：**本文体系结构为上述教程的引用和补充；数据包、资源包相关知识首先请查阅上述资料。**  
+原版模组是数据包和资源包配合的系统工程，其中数据包部分的重中之重是命令组成的函数。因此，请读者清楚：**本文体系结构为上述教程的引用和补充；数据包、资源包相关知识首先请查阅上述资料。**
 ### 如何食用Wiki
 学习原版模组并不需要将wiki完整阅读一遍。我们推荐的方法是将wiki当做字典使用。读者可以先阅读本文下面给出的链接内容，当出现不理解的段落，前往wiki查询相关信息。如果还是不懂，可以打开对应版本的游戏，简单实践并体验一下。
 ### 如何食用本文
-本文中包含有大量的链接，大多数链接中都包含大量的内容。须知人的精力是有限的，在开始自己的数据包之旅前，指望将其中所有的文章全部看过一遍，是绝无可能的。  
-因此，我们推荐读者有选择、有顺序地取用本文的内容。  
+本文中包含有大量的链接，大多数链接中都包含大量的内容。须知人的精力是有限的，在开始自己的数据包之旅前，指望将其中所有的文章全部看过一遍，是绝无可能的。
+因此，我们推荐读者有选择、有顺序地取用本文的内容。
 
 
 - 如果你是零基础的萌新：

--- a/index/资源包实践.md
+++ b/index/资源包实践.md
@@ -8,13 +8,13 @@
 ## 模型实践
 - [Minecraft 原版模组入门教程 - 模型](https://zhangshenxing.github.io/VanillaModTutorial/#%E6%A8%A1%E5%9E%8B)
 - 绕开mj模型大小限制的方法：[旋转拼接](/datapack-index/save/637959.html){target="_blank"}&nbsp;&nbsp;[1200米大刀](https://www.bilibili.com/video/av24626290/)&nbsp;&nbsp;[【魔改材质包】数体积专用-3轴标尺](https://www.bilibili.com/video/av39646162/)
- 
+
 - [物品栏和手部显示不同模型](https://github.com/ShockMicro/CorePerspectiveModels)
 - [【1.14】物品头部/背包/手持显示不同纹理/模型](/datapack-index/save/833056.html){target="_blank"}
 
 ## 着色器实践
 - [渲染玩家皮肤](https://github.com/JNNGL/vanilla-shaders/tree/main/fancy_player_models)
-- [BetterTitle 屏幕文字展示](https://github.com/Huoyuyuyu/BetterTitle)&nbsp;&nbsp;&nbsp;[(展示视频)](https://www.bilibili.com/video/BV1AcvyeyECH/) 
+- [BetterTitle 屏幕文字展示](https://github.com/Huoyuyuyu/BetterTitle)&nbsp;&nbsp;&nbsp;[(展示视频)](https://www.bilibili.com/video/BV1AcvyeyECH/)
 - [VanillaDynamicEmissives](https://github.com/ShockMicro/VanillaDynamicEmissives?) 实现了自发光材质
 - [collection of examples](https://github.com/McTsts/mc-core-shaders?) 一个相对较小的免费使用着色器的集合
 - [optifine-like vanilla shaders](https://github.com/bradleyq/mc_vanilla_shaders?)力求将尽可能多的Optifine着色器添加到“极佳!”画质下使用的后处理管线中


### PR DESCRIPTION
命令格式说明：
[可选输入项]
<参数>
<必选|选择>
[可选|选择]

`/kill [目标]`
的含义是可以选择执行`/kill 目标`，因为`目标`作为输入项直接被填了进去。
正确的格式是
`/kill [<目标>]`

同理：
`spreadplayers <x> <z> <分散间距> <最大范围> [under <最大高度>] <考虑队伍> <传送目标…>`
这里`[under <最大高度>]`中，`under`直接写入，`<最大高度>`需要替换为参数。