### PR TITLE
docs(附录7): 补全着色器教程系列未收录篇目

### DIFF
--- a/index/附录7.md
+++ b/index/附录7.md
@@ -10,8 +10,12 @@
   - [着色器基础教程03：核心着色器的工作流程（中）](/feature/archive/202510/3/content.md)
   - [着色器基础教程04：核心着色器的工作流程（下）](/feature/archive/202511/2/content.md)
   - [附注-核心全局量汇总（上）](/feature/archive/202512/5/content.md)
+- 杂谈：
+  - [着色器的应用与滥用](/feature/archive/202605/2/content.md)
 - 着色器实践篇：
   - [简单2D场景的搭建](/feature/archive/202602/1/content.md)
   - [代码雨制作](/feature/archive/202602/2/content.md)
+  - [灰度和抖动](/feature/archive/202607/3/content.md)
+  - [精准采样纹理](/feature/archive/202607/4/content.md)
 - 着色器进阶篇:
   - [基于物理的渲染（PBR）](/feature/archive/202602/3/content.md)


### PR DESCRIPTION
## 摘要
按《关于着色器教程系列后续安排》的基础 / 实践 / 进阶结构，更新附录7索引，补全由轩宇1725主笔、已在《Feature》上线但尚未链入附录7的着色器教程条目。

## 变更
- **杂谈**（新增小节）：[着色器的应用与滥用](feature/archive/202605/2/content.md)（2026.05）
- **实践篇**：
  - [灰度和抖动](feature/archive/202607/3/content.md)（2026.07）
  - [精准采样纹理](feature/archive/202607/4/content.md)（2026.07）

## 说明
仅修改 index/附录7.md 链接列表，不改文章正文。连接材质等非「着色器教程系列」主笔文未纳入。