### PR TITLE
docs(feature): 202606/2 与徐木弦共同投稿

### DIFF
--- a/en/feature/archive/202606/2/content.md
+++ b/en/feature/archive/202606/2/content.md
@@ -10,6 +10,7 @@ This page was translated with machine translation and may contain inaccuracies. 
 <FeaturedHead
     title="How to adapt single-player games to multiplayer - taking Xu Muxian's Pipes as an example"
     authorName="Xuanyu1725"
+    :extraAuthors="['徐木弦']"
 />
 
 

--- a/en/feature/index/202606.md
+++ b/en/feature/index/202606.md
@@ -50,7 +50,8 @@ This month we have received from many authors about the implementation of the wa
 <IndexCompatible
 title = "How to adapt single-player games to multiplayer - taking Xu Muxian's Pipes as an example"
     url = "../archive/202606/2/content"
-authorName = Xuanyu1725
+    authorName = Xuanyu1725
+    :extraAuthors="['徐木弦']"
 abstract = "This article will be based on Xu Muxian's version of Pipes data pack for multi-player adaptation. As a general example, the function of this data pack is only used as a background and is not a core factor for multi-player compatibility. This article is mainly based on the analysis of ideas and simple modifications to the original data pack for multi-player adaptation. The content is relatively simple."
 />
 

--- a/feature/archive/202606/2/content.md
+++ b/feature/archive/202606/2/content.md
@@ -5,6 +5,7 @@ title: '如何将单人游戏适配多人'
 <FeaturedHead
     title='如何将单人游戏适配多人 - 以徐木弦的 Pipes 为例'
     authorName='轩宇1725'
+    :extraAuthors="['徐木弦']"
 />
 
 

--- a/feature/index/202606.md
+++ b/feature/index/202606.md
@@ -46,6 +46,7 @@ outline: Outline[1]
     title = "如何将单人游戏适配多人 - 以徐木弦的 Pipes 为例"
     url = "../archive/202606/2/content"
     authorName = 轩宇1725
+    :extraAuthors="['徐木弦']"
     abstract = "本文将基于 徐木弦 版本的 Pipes 数据包进行多人适配，作为一个通用的例子，该数据包的功能仅作为背景，并不是多人兼容的核心因素。本文主要基于思路分析并对原数据包进行简单修改进行多人适配，内容较简单。"
 />
 


### PR DESCRIPTION
## 说明

《Feature》2026.06 精选《如何将单人游戏适配多人 - 以徐木弦的 Pipes 为例》改为与徐木弦联投。

该文以徐木弦的 Pipes 为实例，按站内既有 extraAuthors 写法补上共同作者。

## 改动

- feature/index/202606.md、feature/archive/202606/2/content.md
- 对应英文页同步

## 检查

- [x] 共同作者名与 public/authors/徐木弦.json 一致
- [x] 与 202606/0、202603/1 等联投写法对齐
