### PR TITLE
feat: show Mcfpm packages in the wheel index

### DIFF
--- a/.github/workflows/verify-wheel-api.yml
+++ b/.github/workflows/verify-wheel-api.yml
@@ -25,7 +25,6 @@ jobs:
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 24
-          cache: pnpm
 
       - name: Enable the pinned package manager
         run: |

--- a/.github/workflows/verify-wheel-api.yml
+++ b/.github/workflows/verify-wheel-api.yml
@@ -1,0 +1,45 @@
+name: Verify wheel package API integration
+
+on:
+  pull_request:
+    paths:
+      - ".vitepress/vue/wheel/**"
+      - "tests/**"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - ".github/workflows/verify-wheel-api.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out source
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
+        with:
+          persist-credentials: false
+
+      - name: Set up Node.js 24
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Enable the pinned package manager
+        run: |
+          corepack enable
+          corepack prepare pnpm@9.13.2 --activate
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run tests
+        run: pnpm test
+
+      - name: Build VitePress
+        run: pnpm exec vitepress build
+        env:
+          VITEPRESS_BASE: /datapack-index/
+          NODE_OPTIONS: --max-old-space-size=3584

--- a/.vitepress/vue/wheel/AllPage.vue
+++ b/.vitepress/vue/wheel/AllPage.vue
@@ -35,12 +35,13 @@
 <script>
 import FlexSearch from "flexsearch";
 import ResultCard from "./ResultCard.vue";
+import { fetchMcfpmPackages } from "./mcfpmPackages.mjs";
 import { useData } from "vitepress";
 
 // simple localStorage cache configuration
-const CACHE_KEY = "datapack_formatters_cache_v1";
-// default TTL: 24 hours
-const CACHE_TTL = 24 * 60 * 60 * 1000;
+const CACHE_KEY = "datapack_formatters_and_mcfpm_cache_v2";
+// The package API refreshes frequently, so keep the browser cache short.
+const CACHE_TTL = 15 * 60 * 1000;
 
 // IndexedDB helpers
 function openIndexedDB() {
@@ -118,6 +119,11 @@ function sanitizeDataForCache(data, fields = [
 	"cover",
 	"gameversion",
 	"author",
+	"external",
+	"coordinate",
+	"latestVersion",
+	"source",
+	"trust",
 ]) {
 	if (!Array.isArray(data)) return [];
 	return data.map((d) => {
@@ -226,10 +232,25 @@ export default {
 					console.warn("Failed to read IDB cache for formatters.json", e);
 				}
 
-				// fetch fresh if cache missing/expired
-				const response = await fetch("../formatters.json");
-				const data = await response.json();
-				this.data = data;
+				// Fetch the historical static library and the Mcfpm package API independently.
+				// One source can still render when the other is temporarily unavailable.
+				const [staticResult, mcfpmResult] = await Promise.allSettled([
+					fetch("../formatters.json").then((response) => {
+						if (!response.ok) throw new Error(`formatters.json returned HTTP ${response.status}`);
+						return response.json();
+					}),
+					fetchMcfpmPackages(),
+				]);
+				const staticData = staticResult.status === "fulfilled" && Array.isArray(staticResult.value)
+					? staticResult.value
+					: [];
+				const mcfpmData = mcfpmResult.status === "fulfilled" ? mcfpmResult.value : [];
+				if (staticResult.status === "rejected") console.warn("Static library fetch failed", staticResult.reason);
+				if (mcfpmResult.status === "rejected") console.warn("Mcfpm package API fetch failed", mcfpmResult.reason);
+				if (!staticData.length && !mcfpmData.length && staticResult.status === "rejected" && mcfpmResult.status === "rejected") {
+					throw new Error("Both package index sources are unavailable");
+				}
+				this.data = [...mcfpmData, ...staticData];
 				this.index = buildIndexFromData(this.data);
 
 				// write to IndexedDB cache (only plain data)
@@ -264,7 +285,7 @@ export default {
 		submit() {
 			// 在新标签页中打开投稿页面
 			const url =
-				"https://github.com/CR-019/datapack-index/issues/new?template=new_wheel.yaml";
+				"https://github.com/Alumopper/datapack-index-mcfpm-staging/issues/new?template=new_wheel.yaml";
 			try {
 				const win = window.open(url, "_blank");
 				if (win) win.opener = null;

--- a/.vitepress/vue/wheel/ResultCard.vue
+++ b/.vitepress/vue/wheel/ResultCard.vue
@@ -62,7 +62,12 @@ export default {
     methods: {
         onClick() {
             const dest = this.item.path ?? this.item.id ?? null;
-            if (dest) this.$emit("select", "/datapack-index" + dest);
+            if (!dest || typeof dest !== "string") return;
+            if (/^https:\/\//i.test(dest)) {
+                this.$emit("select", dest);
+                return;
+            }
+            this.$emit("select", "/datapack-index" + dest);
         },
 
         tagStyle(tag) {

--- a/.vitepress/vue/wheel/SearchBox.vue
+++ b/.vitepress/vue/wheel/SearchBox.vue
@@ -455,7 +455,7 @@ export default {
 		submit() {
 			// 在新标签页中打开投稿页面
 			const url =
-				"https://github.com/CR-019/datapack-index/issues/new?template=new_wheel.yaml";
+				"https://github.com/Alumopper/datapack-index-mcfpm-staging/issues/new?template=new_wheel.yaml";
 			try {
 				const win = window.open(url, "_blank");
 				if (win) win.opener = null;

--- a/.vitepress/vue/wheel/mcfpmPackages.mjs
+++ b/.vitepress/vue/wheel/mcfpmPackages.mjs
@@ -1,0 +1,74 @@
+export const PACKAGE_API_BASE = "https://package.afox.moe/v1/packages";
+
+function requireString(value, field) {
+	if (typeof value !== "string" || !value || value.length > 512) {
+		throw new Error(`Mcfpm API package has an invalid ${field}`);
+	}
+	return value;
+}
+
+function requireStringArray(value, field) {
+	if (!Array.isArray(value) || value.length > 100 || value.some((entry) => typeof entry !== "string")) {
+		throw new Error(`Mcfpm API package has an invalid ${field}`);
+	}
+	return value;
+}
+
+export function mapMcfpmPackage(item, apiBase = PACKAGE_API_BASE) {
+	if (!item || typeof item !== "object") throw new Error("Mcfpm API package is not an object");
+	const group = requireString(item.group, "group");
+	const name = requireString(item.name, "name");
+	const coordinate = requireString(item.coordinate, "coordinate");
+	const latestVersion = requireString(item.latestVersion, "latestVersion");
+	if (coordinate !== `${group}:${name}`) throw new Error("Mcfpm API package coordinate does not match");
+	const sources = requireStringArray(item.sources, "sources");
+	const types = requireStringArray(item.types, "types");
+	const licenses = requireStringArray(item.licenses, "licenses");
+	const trust = item.trust === "reviewed" ? "Reviewed" : "Community";
+	const sourceLabels = sources.map((source) => source === "nexus" ? "Nexus" : "Maven Central");
+	const tags = ["Mcfpm", trust, ...sourceLabels, ...types].slice(0, 8);
+	const detailUrl = `${apiBase}/${encodeURIComponent(group)}/${encodeURIComponent(name)}`;
+	return {
+		id: `mcfpm:${coordinate}`,
+		coordinate,
+		name,
+		description: typeof item.description === "string" && item.description
+			? item.description
+			: `${coordinate} · Mcfpm package`,
+		tokens: [coordinate, name, latestVersion, ...sources, ...types, ...licenses].join(" "),
+		tags,
+		path: detailUrl,
+		external: true,
+		cover: null,
+		gameversion: [`Mcfpm ${latestVersion}`],
+		author: [{ name: group }],
+		latestVersion,
+		source: sources,
+		trust: item.trust,
+	};
+}
+
+export async function fetchMcfpmPackages(fetchImpl = fetch, apiBase = PACKAGE_API_BASE) {
+	const packages = [];
+	const seenCursors = new Set();
+	let cursor = null;
+	for (let page = 0; page < 100; page += 1) {
+		const url = new URL(apiBase);
+		url.searchParams.set("limit", "100");
+		if (cursor) url.searchParams.set("cursor", cursor);
+		const response = await fetchImpl(url.toString(), { headers: { Accept: "application/json" } });
+		if (!response || !response.ok) {
+			throw new Error(`Mcfpm package API returned HTTP ${response?.status ?? "unknown"}`);
+		}
+		const payload = await response.json();
+		if (!payload || !Array.isArray(payload.items)) throw new Error("Mcfpm package API returned invalid data");
+		packages.push(...payload.items.map((item) => mapMcfpmPackage(item, apiBase)));
+		cursor = payload.nextCursor;
+		if (cursor == null) return packages;
+		if (typeof cursor !== "string" || !cursor || seenCursors.has(cursor)) {
+			throw new Error("Mcfpm package API returned an invalid pagination cursor");
+		}
+		seenCursors.add(cursor);
+	}
+	throw new Error("Mcfpm package API pagination exceeded the safety limit");
+}

--- a/tests/mcfpm-package-index.test.mjs
+++ b/tests/mcfpm-package-index.test.mjs
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { fetchMcfpmPackages, mapMcfpmPackage } from "../.vitepress/vue/wheel/mcfpmPackages.mjs";
+
+
+const PACKAGE = {
+	coordinate: "org.example:demo",
+	group: "org.example",
+	name: "demo",
+	latestVersion: "1.2.3",
+	trust: "reviewed",
+	sources: ["nexus"],
+	types: ["minecraft.datapack"],
+	licenses: ["MIT"],
+	description: null,
+};
+
+
+test("maps a package summary to an external library card", () => {
+	const card = mapMcfpmPackage(PACKAGE, "https://packages.example/v1/packages");
+	assert.equal(card.id, "mcfpm:org.example:demo");
+	assert.equal(card.path, "https://packages.example/v1/packages/org.example/demo");
+	assert.equal(card.external, true);
+	assert.deepEqual(card.author, [{ name: "org.example" }]);
+	assert.ok(card.tags.includes("Reviewed"));
+});
+
+
+test("fetches all bounded API pages", async () => {
+	const requested = [];
+	const pages = [
+		{ items: [PACKAGE], nextCursor: "page-2" },
+		{ items: [{ ...PACKAGE, coordinate: "org.example:other", name: "other" }], nextCursor: null },
+	];
+	const fetchImpl = async (url) => {
+		requested.push(url);
+		return { ok: true, status: 200, json: async () => pages.shift() };
+	};
+	const result = await fetchMcfpmPackages(fetchImpl, "https://packages.example/v1/packages");
+	assert.equal(result.length, 2);
+	assert.match(requested[1], /cursor=page-2/);
+});
+
+
+test("rejects a mismatched API coordinate", () => {
+	assert.throws(() => mapMcfpmPackage({ ...PACKAGE, coordinate: "org.example:other" }), /does not match/);
+});


### PR DESCRIPTION
## Summary

- merge the existing static wheel catalog with the read-only Mcfpm package API at runtime
- label Nexus packages as reviewed and Maven Central packages as community entries
- preserve the historical catalog when the API is unavailable
- point submissions to the public audited staging repository
- add a pinned pull-request test and VitePress build workflow

The API endpoint is `https://package.afox.moe/v1/packages`; DNS/Caddy rollout is handled separately on the API host.