### PR TITLE
fix: cache reactive wheel data as plain objects

### DIFF
--- a/.vitepress/vue/wheel/AllPage.vue
+++ b/.vitepress/vue/wheel/AllPage.vue
@@ -126,7 +126,7 @@ function sanitizeDataForCache(data, fields = [
 	"trust",
 ]) {
 	if (!Array.isArray(data)) return [];
-	return data.map((d) => {
+	const sanitized = data.map((d) => {
 		const out = {};
 		for (const f of fields) {
 			// support nested fields 'a.b'
@@ -162,6 +162,11 @@ function sanitizeDataForCache(data, fields = [
 		}
 		return out;
 	});
+	// Vue makes component data reactive. Nested arrays and objects can therefore
+	// still be Proxy instances even though the outer object above is plain.
+	// IndexedDB's structured-clone algorithm rejects Proxy values, while a JSON
+	// round trip produces the plain data structures this cache is intended to hold.
+	return JSON.parse(JSON.stringify(sanitized));
 }
 
 export default {


### PR DESCRIPTION
The all-resources page stores Vue reactive data in IndexedDB. Nested arrays remain Proxy instances and fail the structured-clone algorithm with DataCloneError. Convert the sanitized cache payload through JSON so IndexedDB receives only plain values.\n\nVerified manually on the deployed page: the package API responds successfully and all three Mcfpm cards render; this patch targets the remaining cache warning.