### PR TITLE
fix: match native Wheel rendering

### DIFF
--- a/.vitepress/vue/wheel/PackagePage.vue
+++ b/.vitepress/vue/wheel/PackagePage.vue
@@ -316,30 +316,7 @@ onMounted(async () => {
 
 .detail-grid { display: grid; grid-template-columns: minmax(0, 1fr) 320px; gap: 32px; align-items: start; }
 .readme-panel { min-width: 0; }
-.package-sidebar { position: sticky; top: 90px; display: flex; min-width: 0; margin-top: 28px; flex-direction: column; gap: 18px; }
-.package-markdown { color: var(--vp-c-text-1); font-size: 16px; line-height: 1.75; }
-.package-markdown :deep(h1), .package-markdown :deep(h2), .package-markdown :deep(h3), .package-markdown :deep(h4) { position: relative; scroll-margin-top: 90px; color: var(--vp-c-text-1); font-weight: 700; line-height: 1.3; }
-.package-markdown :deep(h1) { margin: 0 0 24px; font-size: 32px; }
-.package-markdown :deep(h2) { margin: 36px 0 18px; padding-top: 22px; border-top: 1px solid var(--vp-c-divider); font-size: 24px; }
-.package-markdown :deep(h3) { margin: 28px 0 14px; font-size: 20px; }
-.package-markdown :deep(h4) { margin: 22px 0 12px; font-size: 17px; }
-.package-markdown :deep(p) { margin: 16px 0; line-height: 1.8; }
-.package-markdown :deep(a) { color: var(--vp-c-brand-1); font-weight: 500; text-decoration: underline; text-decoration-color: color-mix(in srgb, var(--vp-c-brand-1) 35%, transparent); text-underline-offset: 3px; }
-.package-markdown :deep(a:hover) { color: var(--vp-c-brand-2); text-decoration-color: currentColor; }
-.package-markdown :deep(ul), .package-markdown :deep(ol) { margin: 16px 0; padding-left: 1.6rem; }
-.package-markdown :deep(li) { margin: 7px 0; line-height: 1.75; }
-.package-markdown :deep(blockquote) { margin: 20px 0; padding: 10px 18px; border-left: 4px solid var(--vp-c-brand-1); border-radius: 0 8px 8px 0; background: var(--vp-c-bg-soft); color: var(--vp-c-text-2); }
-.package-markdown :deep(blockquote p) { margin: 6px 0; }
-.package-markdown :deep(code) { padding: 3px 6px; border-radius: 5px; background: var(--vp-code-bg); color: var(--vp-code-color); font-family: var(--vp-font-family-mono); font-size: 0.875em; }
-.package-markdown :deep(pre) { margin: 20px 0; overflow-x: auto; padding: 18px 20px; border-radius: 10px; background: var(--vp-code-block-bg); line-height: 1.7; white-space: pre !important; }
-.package-markdown :deep(div[class*="language-"] > pre) { margin: 0; }
-.package-markdown :deep(pre code) { display: block; padding: 0; background: transparent; color: var(--vp-code-block-color); font-size: 14px; white-space: pre !important; word-break: normal; }
-.package-markdown :deep(table) { display: block; width: 100%; margin: 20px 0; overflow-x: auto; border-collapse: collapse; font-size: 14px; }
-.package-markdown :deep(th), .package-markdown :deep(td) { min-width: 110px; padding: 10px 14px; border: 1px solid var(--vp-c-divider); text-align: left; vertical-align: top; }
-.package-markdown :deep(th) { background: var(--vp-c-bg-soft); font-weight: 700; }
-.package-markdown :deep(tr:nth-child(2n) td) { background: color-mix(in srgb, var(--vp-c-bg-soft) 65%, transparent); }
-.package-markdown :deep(hr) { margin: 32px 0; border: 0; border-top: 1px solid var(--vp-c-divider); }
-.package-markdown :deep(img) { max-width: 100%; border-radius: 10px; box-shadow: 0 6px 22px rgba(12, 24, 40, 0.08); }
+.package-sidebar { display: flex; min-width: 0; margin-top: 28px; flex-direction: column; gap: 18px; }
 .metadata-panel { padding: 18px; border: 1px solid var(--vp-c-divider); border-radius: 14px; background: var(--vp-c-bg-soft); }
 .metadata-panel h2 { margin: 0 0 12px; border: 0; padding: 0; font-size: 17px; }
 .metadata-panel dl { margin: 0; }

--- a/.vitepress/vue/wheel/runtimeMarkdown.mjs
+++ b/.vitepress/vue/wheel/runtimeMarkdown.mjs
@@ -264,18 +264,26 @@ function renderContainerTitle(value, documentPath, baseUrl) {
 	return markdown.renderInline(String(value || ""));
 }
 
+function normalizeNbtTreeMarkup(html) {
+	return String(html).replace(
+		/(<div\b[^>]*\bclass=(['"])[^'"]*\bnbttree\b[^'"]*\2[^>]*>\s*)<p>((?:(?!<\/?div\b)[\s\S])*?)<\/p>/gi,
+		"$1$3",
+	);
+}
+
 function codeBlock(code, language, highlighter, english) {
 	const requested = String(language || "text").split(/[\s{[]/, 1)[0].toLowerCase() || "text";
 	const aliases = { js: "javascript", ts: "typescript", yml: "yaml", sh: "bash", text: "plaintext", txt: "plaintext" };
 	const normalized = aliases[requested] || requested;
 	const loaded = highlighter?.getLoadedLanguages?.() || [];
 	const resolved = loaded.includes(normalized) ? normalized : "plaintext";
-	if (!highlighter) return "";
-	const highlighted = highlighter.codeToHtml(code.trimEnd(), {
-		lang: resolved,
-		themes: { light: "github-light", dark: "github-dark" },
-		defaultColor: false,
-	}).replace(/<pre class="([^"]*)"/, '<pre v-pre class="$1 vp-code"');
+	const highlighted = highlighter
+		? highlighter.codeToHtml(code.trimEnd(), {
+			lang: resolved,
+			themes: { light: "github-light", dark: "github-dark" },
+			defaultColor: false,
+		}).replace(/<pre class="([^"]*)"/, '<pre v-pre class="$1 vp-code"')
+		: `<pre v-pre class="shiki vp-code"><code>${escapeHtml(code.trimEnd())}</code></pre>`;
 	return `<div class="language-${escapeAttribute(requested)} vp-adaptive-theme"><button title="${english ? "Copy code" : "复制代码"}" class="copy" type="button"></button><span class="lang">${escapeHtml(requested)}</span>${highlighted}</div>`;
 }
 
@@ -293,8 +301,13 @@ export function renderRuntimeMarkdown(source, { highlighter = null, english = fa
 		html: true,
 		linkify: true,
 		typographer: false,
-		highlight: (code, language) => codeBlock(code, language, highlighter, english),
 	});
+	markdown.renderer.rules.fence = (tokens, index) => codeBlock(
+		tokens[index].content,
+		tokens[index].info,
+		highlighter,
+		english,
+	);
 	markdown.use(footnote);
 	useKatex(markdown);
 	useGitHubAlerts(markdown);
@@ -332,11 +345,11 @@ export function renderRuntimeMarkdown(source, { highlighter = null, english = fa
 		return defaultLinkOpen(tokens, index, options, env, self);
 	};
 
-	return markdown.render(transformContainers(
+	return normalizeNbtTreeMarkup(markdown.render(transformContainers(
 		trusted,
 		english,
 		(title) => renderContainerTitle(title, documentPath, baseUrl),
-	))
+	)))
 		.replaceAll("{{", "&#123;&#123;")
 		.replaceAll("}}", "&#125;&#125;");
 }

--- a/tests/runtime-markdown.test.mjs
+++ b/tests/runtime-markdown.test.mjs
@@ -80,8 +80,20 @@ test("preserves the NBT tree wrapper and node controls", () => {
 </div>
 :::`, { baseUrl: "/datapack-index/" });
 	assert.match(html, /<details class="details custom-block"><summary>View <a href="\/datapack-index\/feature\/mcdoc">mcdoc<\/a><\/summary>/);
-	assert.match(html, /<div class="nbttree">/);
+	assert.match(html, /<div class="nbttree">\s*<node type="compound" name="root" \/>/);
+	assert.doesNotMatch(html, /<div class="nbttree">\s*<p>/);
 	assert.match(html, /<node type="compound" name="root" \/>/);
 	assert.match(html, /<node type="string" name="name" required \/>/);
 	assert.match(html, /<ul>/);
+});
+
+test("renders fenced code with the same single wrapper structure as VitePress", () => {
+	const highlighter = {
+		getLoadedLanguages: () => ["mcfunction"],
+		codeToHtml: (code) => `<pre class="shiki"><code>${code}</code></pre>`,
+	};
+	const html = renderRuntimeMarkdown("```mcfunction\nsay hi\n```", { highlighter });
+	assert.match(html, /^<div class="language-mcfunction vp-adaptive-theme">/);
+	assert.match(html, /<pre v-pre class="shiki vp-code"><code>say hi<\/code><\/pre><\/div>$/);
+	assert.doesNotMatch(html, /<pre><code class="language-mcfunction">/);
 });

--- a/tests/wheel-css-output.test.mjs
+++ b/tests/wheel-css-output.test.mjs
@@ -31,7 +31,8 @@ test("wheel runtime uses the generated static fallback without restoring the old
 	assert.doesNotMatch(nbtTree.markdown, /<InfoCard/);
 });
 
-test("runtime code blocks do not add margins inside their language wrapper", () => {
+test("runtime documentation inherits the library's native Markdown styles", () => {
 	const packagePage = fs.readFileSync(path.join(import.meta.dirname, "..", ".vitepress", "vue", "wheel", "PackagePage.vue"), "utf8");
-	assert.match(packagePage, /div\[class\*="language-"\] > pre\) \{ margin: 0; \}/);
+	assert.doesNotMatch(packagePage, /\.package-markdown\s*:deep/);
+	assert.doesNotMatch(packagePage, /\.package-sidebar\s*\{[^}]*position:\s*sticky/);
 });


### PR DESCRIPTION
Fix runtime Wheel detail pages to use the same Markdown and NBT-tree DOM/styles as native VitePress pages. Remove the nested code-block wrapper, let the sidebar scroll naturally, and add regression coverage.